### PR TITLE
feat: set default locale to zh-TW

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ APP_URL=http://localhost
 # You should not need this, unless you are using subdirectory config.
 APP_FORCE_URL=false
 
+# Default application locale
+APP_DEFAULT_LOCALE=zh-TW
+
 # Database information
 # To keep this information secure, we urge you to change the default password
 # Currently only "mysql" compatible servers are working

--- a/config/app.php
+++ b/config/app.php
@@ -92,7 +92,7 @@ return [
     |
     */
 
-    'locale' => env('APP_DEFAULT_LOCALE', 'en'),
+    'locale' => env('APP_DEFAULT_LOCALE', 'zh-TW'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -70,7 +70,7 @@ return [
     |
     */
 
-    'currency_locale' => env('CASHIER_CURRENCY_LOCALE', 'en'),
+    'currency_locale' => env('CASHIER_CURRENCY_LOCALE', 'zh_TW'),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -19,18 +19,18 @@ Vue.filter('formatDate', function(value) {
 window.marked = require('marked');
 
 // i18n
-import messages from '../../public/js/langs/en.json';
+import messages from '../../public/js/langs/zh-TW.json';
 import pluralization from './pluralization.js';
 
 export default {
   i18n: new VueI18n({
-    locale: 'en', // set locale
+    locale: 'zh-TW', // set locale
     fallbackLocale: 'en',
-    messages: {'en': messages},
+    messages: {'zh-TW': messages},
     pluralizationRules: pluralization,
   }),
-  
-  loadedLanguages : ['en'], // our default language that is preloaded
+
+  loadedLanguages : ['zh-TW'], // our default language that is preloaded
   
   _setI18nLanguage (lang) {
     this.i18n.locale = lang;
@@ -56,7 +56,7 @@ export default {
       if (set) {
         this._setI18nLanguage(lang);
       }
-      moment.locale(lang === 'zh' ? 'zh-cn' : lang);
+      moment.locale(lang === 'zh' ? 'zh-cn' : lang === 'zh-TW' ? 'zh-tw' : lang);
       return i18n;
     });
   }


### PR DESCRIPTION
## Summary
- default interface to Traditional Chinese
- load zh-TW translations on frontend and set currency locale

## Testing
- `yarn test` *(fails: package doesn't seem to be present in lockfile; run "yarn install" to update the lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_6894b8edaaf48324aab4b26a97b51f14